### PR TITLE
Reduced menu tray to 80% to stop content going under the main layout con...

### DIFF
--- a/lib/generators/ornament/templates/app/assets/stylesheets/components/_layout.css.scss
+++ b/lib/generators/ornament/templates/app/assets/stylesheets/components/_layout.css.scss
@@ -55,6 +55,7 @@ $layout-breakpoint:       960px   !default;
   .layout-open .layout--mobile-tray {
     display: block;
     min-height: 100%;
+    width: 80%;
   }
 
   .layout-open .layout--content {


### PR DESCRIPTION
Super simple change to reduce the mobile menu tray (`.layout--mobile-tray`) to 80% to stop really long links going underneath the main layout content section (`.layout--content`)
