### PR TITLE
Added anti-aliasing to button reset styles

### DIFF
--- a/lib/generators/ornament/templates/app/assets/stylesheets/ornament/_reset.css.scss
+++ b/lib/generators/ornament/templates/app/assets/stylesheets/ornament/_reset.css.scss
@@ -34,6 +34,7 @@
 button {
   -webkit-appearance: inherit;
   -webkit-box-align: inherit;
+  -webkit-font-smoothing: antialiased;
   background: transparent;
   border: none;
   color: inherit;


### PR DESCRIPTION
A small fix for buttons to render using `-webkit-font-smoothing: antialiased`. Normal links had this already but the buttons did not, which resulted in slightly different looking links when a link appears next to a button:

![screen shot 2013-06-28 at 5 00 15 pm](https://f.cloud.github.com/assets/685024/720585/e0dadbc6-dfc4-11e2-93af-c7e98c4fee15.png)

It's a little hard to see, but the buttons look slightly more bold than the links. 
