### PR TITLE
Added commented simplenav tags to global.html for the generator and dumm...

### DIFF
--- a/lib/generators/ornament/templates/app/views/layouts/global.html.erb
+++ b/lib/generators/ornament/templates/app/views/layouts/global.html.erb
@@ -39,9 +39,7 @@
     <div class="layout">
 
       <div class="layout--mobile-tray">
-        mobile nav
-        <br />
-        mobile nav
+        <%#= render_navigation renderer: :sf_menu, items: NavItem.navigation("header_navigation", binding()), level: 1..2, expand_all: true, dom_id: "", dom_class: "navigation-mobile" , link: { class: 'subsection' } %>
       </div>
 
       <div class="layout--content">
@@ -56,7 +54,8 @@
           <header class="layout--desktop-header" role="banner">
             <!-- The container is optional. -->
             <div class="layout--container">
-              desktop header
+              Desktop header
+              <%#= render_navigation renderer: :sf_menu, items: NavItem.navigation("header_navigation", binding()), level: 1..2, expand_all: true, dom_id: "", dom_class: "navigation-primary" , link: { class: 'subsection' } %>
             </div>
           </header>
         </div>
@@ -82,7 +81,7 @@
       <footer class="layout--desktop-footer" role="contentinfo">
         <!-- The container is optional. -->
         <div class="layout--container">
-          desktop footer
+          <%#= render_navigation renderer: :sf_menu, items: NavItem.navigation("footer_navigation", binding()), level: 1, expand_all: true, dom_id: "", dom_class: "navigation-footer" , link: { class: 'subsection' } %>
         </div>
       </footer>
 

--- a/test/dummy/app/views/layouts/global.html.erb
+++ b/test/dummy/app/views/layouts/global.html.erb
@@ -37,9 +37,7 @@
     <div class="layout">
 
       <div class="layout--mobile-tray">
-        mobile nav
-        <br />
-        mobile nav
+        <%#= render_navigation renderer: :sf_menu, items: NavItem.navigation("header_navigation", binding()), level: 1..2, expand_all: true, dom_id: "", dom_class: "navigation-mobile" , link: { class: 'subsection' } %>
       </div>
 
       <div class="layout--content">
@@ -54,7 +52,7 @@
           <header class="layout--desktop-header">
             <!-- The container is optional. -->
             <div class="layout--container">
-              desktop header
+              <%#= render_navigation renderer: :sf_menu, items: NavItem.navigation("header_navigation", binding()), level: 1..2, expand_all: true, dom_id: "", dom_class: "navigation-primary" , link: { class: 'subsection' } %>
             </div>
           </header>
         </div>
@@ -72,7 +70,7 @@
 
         <!-- The mobile footer is optional. -->
         <footer class="layout--mobile-footer">
-          mobile footer
+          <%#= render_navigation renderer: :sf_menu, items: NavItem.navigation("footer_navigation", binding()), level: 1, expand_all: true, dom_id: "", dom_class: "navigation-footer" , link: { class: 'subsection' } %>
         </footer>
 
       </div>


### PR DESCRIPTION
This could be potentially controversial since it's something more specifically for koi, but would be super handy to have there so we don't need to look up or remember the tag. 

I've added in a simplenav tag in to the header (targeting key: header_navigation, levels 1+2), mobile tray (header_navigation, levels 1+2) and footer (footer_navigation, level 1)

I have commented them out by default so the dummy app doesn't throw errors. 
Let me know what you think :)
