### PR TITLE
Fixed js error when precompiling assets for production deploy

### DIFF
--- a/lib/generators/ornament/templates/app/assets/javascripts/components/toggle.js
+++ b/lib/generators/ornament/templates/app/assets/javascripts/components/toggle.js
@@ -56,7 +56,7 @@
 
       // Get all anchors that do the same thing as the
       // current anchor
-      getAllAnchorsForAnchor($anchor, inclusive) {
+      getAllAnchorsForAnchor: function($anchor, inclusive) {
         inclusive = inclusive || false;
         var id = $anchor.attr(Toggle.anchorSelector);
         return $("[" + Toggle.anchorSelector + "='" + id + "']");
@@ -67,8 +67,8 @@
         return $anchor.is("[" + Toggle.customSpeedSelector + "]") ? parseInt($anchor.attr(Toggle.customSpeedSelector)) : Toggle.toggleSpeed;
       },
 
-      // Get the other anchors for a toggle group 
-      // pass in inclusive: true to include the same anchor in the 
+      // Get the other anchors for a toggle group
+      // pass in inclusive: true to include the same anchor in the
       // group of elements that are returned
       getTogglesInGroup: function($anchor,inclusive){
         inclusive = inclusive || false;
@@ -87,7 +87,7 @@
         $anchors.addClass(Toggle.toggleClass);
       },
 
-      // Unsets all anchors for this id as active 
+      // Unsets all anchors for this id as active
       unsetAnchorActive: function($anchor){
         var $anchors = Toggle.getAllAnchorsForAnchor($anchor);
         $anchors.removeClass(Toggle.toggleClass);
@@ -183,7 +183,7 @@
           return false;
         }
 
-        // Determine which way the pane needs to be 
+        // Determine which way the pane needs to be
         // toggled
         if(Toggle.isToggledOn($anchor)) {
           Toggle.toggleOff($anchor, $pane);
@@ -255,8 +255,8 @@
             Toggle.toggle($anchor, $pane);
           });
 
-          // Clicking away from the toggles shoud hide 
-          // the temporary toggles 
+          // Clicking away from the toggles shoud hide
+          // the temporary toggles
           if($anchor.is("[" + Toggle.temporaryAnchorSelector + "]")) {
             var listenForThisPaneClick = function(event){
               var $target = $(event.target);


### PR DESCRIPTION
@dbaines I found this syntax error when precompiling assets on a production deploy of a new KOI project. I fixed for the specific project but this should fix for future KOI bootstrap projects.