### PR TITLE
Feature/improving generator

### DIFF
--- a/lib/generators/ornament/ornament_generator.rb
+++ b/lib/generators/ornament/ornament_generator.rb
@@ -71,6 +71,7 @@ class OrnamentGenerator < Rails::Generators::Base
         directory "app/assets/icons"
 
         copy_file "config/initializers/simple_form.rb"
+        copy_file "config/initializers/ornament.rb"
         copy_file "../../../../test/dummy/config/initializers/datetime_formats_ornament.rb", "config/initializers/datetime_formats_ornament.rb"
         copy_file "config/locales/en.yml"
 
@@ -119,10 +120,6 @@ class OrnamentGenerator < Rails::Generators::Base
     GEMS.each do |name, version|
      puts "   gem #{name}, #{version}"
     end
-    puts ""
-    puts "Please add this line to asset.rb:"
-    puts ""
-    puts "  Rails.application.config.assets.precompile += %w( application_split2.css  selectivizr.js respond.js application_bottom.js styleguide.css styleguide_split2.css styleguide.js )"
     puts ""
     puts "Then bundle and restart your server"
     puts ""

--- a/lib/generators/ornament/ornament_generator.rb
+++ b/lib/generators/ornament/ornament_generator.rb
@@ -15,7 +15,7 @@ class OrnamentGenerator < Rails::Generators::Base
   GEMS = {
     'sass-rails'    => '~> 5.0.6',
     'uglifier'      => '~> 3.0.4',
-    'compass-rails' => '~> 4.3.4',
+    'compass-rails' => '~> 3.0.2',
     'htmlentities'  => '~> 4.3.4',
     'css_splitter'  => '~> 0.4.6',
   }

--- a/lib/generators/ornament/ornament_generator.rb
+++ b/lib/generators/ornament/ornament_generator.rb
@@ -12,7 +12,22 @@ class OrnamentGenerator < Rails::Generators::Base
   class_option :example,      :type => :boolean, :default => false
   class_option :uploader,     :type => :boolean, :default => true
 
+  GEMS = {
+    'sass-rails'    => '~> 5.0.6',
+    'uglifier'      => '~> 3.0.4',
+    'compass-rails' => '~> 4.3.4',
+    'htmlentities'  => '~> 4.3.4',
+    'css_splitter'  => '~> 0.4.6',
+  }
+
   def generate
+
+    if options.gems?
+      gemfile = File.read('Gemfile')
+      GEMS.each do |name, version|
+        gem name.dup, version unless gemfile.include?(name)
+      end
+    end
 
     if options.settings?
       copy_file "../../../../test/dummy/app/assets/stylesheets/_settings.scss", "app/assets/stylesheets/_settings.scss"
@@ -34,7 +49,7 @@ class OrnamentGenerator < Rails::Generators::Base
         route "end"
         route "  post :image, on: :collection"
         route "resources :uploads do"
-      
+
         copy_file "app/controllers/uploads_controller.rb"
         copy_file "app/views/koi/crud/_form_field_uploader.html.erb"
 
@@ -74,7 +89,7 @@ class OrnamentGenerator < Rails::Generators::Base
         directory "vendor/assets"
       end
 
-      if options.layouts? 
+      if options.layouts?
         directory "app/views/layouts"
         directory "app/views/errors"
         directory "app/views/kaminari"
@@ -101,11 +116,9 @@ class OrnamentGenerator < Rails::Generators::Base
     puts ""
     puts "Please ensure the following gems are in your local Gemfile:"
     puts ""
-    puts "  gem 'sass-rails', '~> 5.0.6'"
-    puts "  gem 'uglifier', '~> 3.0.4'"
-    puts "  gem 'compass-rails', '~> 4.3.4'"
-    puts "  gem 'htmlentities', '~> 4.3.4'"
-    puts "  gem 'css_splitter', '~> 0.4.6'"
+    GEMS.each do |name, version|
+     puts "   gem #{name}, #{version}"
+    end
     puts ""
     puts "Please add this line to asset.rb:"
     puts ""

--- a/lib/generators/ornament/templates/app/views/styleguide/generating_ornament.html.erb
+++ b/lib/generators/ornament/templates/app/views/styleguide/generating_ornament.html.erb
@@ -2,21 +2,27 @@
 
 <div class="content-spacing">
 
-  <h2 class="heading-two">Add required Gems</h2>
-
-  <p>Add these gems to your Gemfile:</p>
-
-  <pre class="sg-pre">gem 'sass-rails', '~> 5.0.6'
-gem 'uglifier', '~> 3.0.4'
-gem 'compass-rails', '~> 4.3.4'
-gem 'htmlentities', '~> 4.3.4'
-gem 'css_splitter', '~> 0.4.6'</pre>
-
-  <p>Then simply run the ornament generator:</p>
+  <p>Simply run the ornament generator:</p>
 
   <pre class="sg-pre">rails generate ornament</pre>
 
-  <p>Once generated add the following assets to your <code>assets.rb</code> file:</p>
+  <hr />
+
+  <h2 class="heading-two">Required Gems</h2>
+
+  <p>Make sure these gems to your Gemfile:</p>
+
+  <pre class="sg-pre">gem 'sass-rails', '~> 5.0.6'
+gem 'uglifier', '~> 3.0.4'
+gem 'compass-rails', '~> 3.0.2'
+gem 'htmlentities', '~> 4.3.4'
+gem 'css_splitter', '~> 0.4.6'</pre>
+
+  <hr />
+
+  <h2 class="heading-two">Asset Precompilation</h2>
+
+  <p>The <code>ornament</code> initialiser will add this line to make sure the required assets get precompiled:</p>
 
   <pre class="sg-pre">Rails.application.config.assets.precompile += %w( application_split2.css  selectivizr.js respond.js application_bottom.js styleguide.css styleguide_split2.css styleguide.js )</pre>
 

--- a/lib/generators/ornament/templates/config/initializers/ornament.rb
+++ b/lib/generators/ornament/templates/config/initializers/ornament.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( application_split2.css  selectivizr.js respond.js application_bottom.js styleguide.css styleguide_split2.css styleguide.js )


### PR DESCRIPTION
- added missing gems directly to Gemfile if they're not already in there

    Reading from the Gemfile is perhaps not the optimal way to check whether the gem is already a dependency of the project (since it might be a dependency of another gem), but it's easy and obvious, and I doubt ornament will be importing things that other gems list as dependencies. 

- configured ornament's precompiled assets in an `ornament.rb` initializer. 