### PR TITLE
Replaced skip_before_filter with skip_before_action

### DIFF
--- a/lib/generators/ornament/templates/app/controllers/uploads_controller.rb
+++ b/lib/generators/ornament/templates/app/controllers/uploads_controller.rb
@@ -1,6 +1,6 @@
 class UploadsController < CrudController
 
-  skip_before_filter :verify_authenticity_token, only: [:create, :image]
+  skip_before_action :verify_authenticity_token, only: [:create, :image]
 
   def create
     image = Image.new


### PR DESCRIPTION
_filter is depricated in Rails 4 and removed in Rails 5